### PR TITLE
introduce makefiles for easy building

### DIFF
--- a/LV2/kpp_bluedream/Makefile
+++ b/LV2/kpp_bluedream/Makefile
@@ -2,7 +2,7 @@
 	user = $(shell whoami)
 	ifeq ($(user),root)
 	INSTALL_LV2_DIR = /usr/lib/lv2
-	INSTALL_LADSPA_DIR = /usr/lib/lv2
+	INSTALL_LADSPA_DIR = /usr/lib/ladspa
 	else 
 	INSTALL_LV2_DIR = ~/.lv2
 	INSTALL_LADSPA_DIR = ~/.ladspa

--- a/LV2/kpp_bluedream/Makefile
+++ b/LV2/kpp_bluedream/Makefile
@@ -1,0 +1,79 @@
+	# check if user is root
+	user = $(shell whoami)
+	ifeq ($(user),root)
+	INSTALL_LV2_DIR = /usr/lib/lv2
+	INSTALL_LADSPA_DIR = /usr/lib/lv2
+	else 
+	INSTALL_LV2_DIR = ~/.lv2
+	INSTALL_LADSPA_DIR = ~/.ladspa
+	endif
+
+	# set bundle name
+	NAME = kpp_bluedream
+	BUNDLE = $(NAME).lv2
+	VER = 1.0
+	# set compile flags
+	CXXFLAGS += -shared -pthread -O2 -fPIC -Wl,--no-as-needed 
+	LDFLAGS +=  -lm -I. '-DDLLEXT=".so"' '-DPLUGIN_URI="https://faustlv2.bitbucket.io/$(NAME)"' -DFAUST_META=1 -DFAUST_MIDICC=1 -DFAUST_MTS=1 -DFAUST_UI=0 -DVOICE_CTRLS=1 
+	GUI_LDFLAGS += -I. -lm `pkg-config --cflags --libs cairo` -L/usr/X11/lib -lX11  -DPLUGIN_URI=\"https://faustlv2.bitbucket.io/$(NAME)\" -DFAUST_META=1 -DFAUST_MIDICC=1 -DFAUST_MTS=1 -DFAUST_UI=1 -DVOICE_CTRLS=1
+	# invoke build files
+	OBJECTS = faust-generated/$(NAME).cpp 
+	GUI_OBJECTS = $(NAME)_ui.src/$(NAME)_gui.c
+	## output style (bash colours)
+	BLUE = "\033[1;34m"
+	RED =  "\033[1;31m"
+	NONE = "\033[0m"
+
+.PHONY : all faust clean gui nogui LV2 LADSPA install uninstall 
+
+all : gui
+	@mkdir -p ./$(BUNDLE)
+	@mv ./*.so ./$(BUNDLE)
+	@if [ -f ./$(BUNDLE)/$(NAME).so ]; then echo $(BLUE)"build finish, now run make install"; \
+	else echo $(RED)"sorry, build failed"; fi
+	@echo $(NONE)
+
+LADSPA :
+	@faust2ladspa ../../LADSPA/$(NAME)/$(NAME).dsp
+
+LV2 : all
+
+faust:
+	@echo $(BLUE)"regenerate from faust dsp file"$(NONE)
+	@mkdir -p ./faust-temp
+	@cp $(NAME).dsp  faust-temp
+	@faust2lv2 -keep ./faust-temp/$(NAME).dsp
+	@cp ./faust-temp/$(NAME)/$(NAME).cpp ./faust-generated
+	@rm -rf faust-temp
+	@echo ". ." $(BLUE)", done"$(NONE)
+
+clean :
+	@rm -f ./$(BUNDLE)/$(NAME).so
+	@rm -f ./$(BUNDLE)/$(NAME)ui.so
+	@rm -f ../../LADSPA/$(NAME)/$(NAME).su
+	@echo $(BLUE)"clean up"$(NONE)
+
+install :
+	@if [ -f ../../LADSPA/$(NAME)/$(NAME).so ]; then \
+	echo $(BLUE)"install LADSPA version to $(INSTALL_LADSPA_DIR)"; \
+	mkdir -p $(DESTDIR)$(INSTALL_LADSPA_DIR); \
+	cp -r ../../LADSPA/$(NAME)/$(NAME).so $(DESTDIR)$(INSTALL_LADSPA_DIR)/$(NAME).so; fi
+ifneq ("$(wildcard ./$(BUNDLE))","")
+	@mkdir -p $(DESTDIR)$(INSTALL_LV2_DIR)/$(BUNDLE)
+	@echo $(BLUE)"install LV2 version to $(INSTALL_LV2_DIR)"$(NONE)
+	@cp -r ./$(BUNDLE)/* $(DESTDIR)$(INSTALL_LV2_DIR)/$(BUNDLE)
+else
+	@echo ". ." $(BLUE)", you must build first"$(NONE)
+endif
+
+uninstall :
+	@rm -rf $(INSTALL_LV2_DIR)/$(BUNDLE)
+	@rm -rf $(INSTALL_LADSPA_DIR)/$(NAME).so
+	@echo ". ." $(BLUE)", done"$(NONE)
+
+gui : 
+	$(CXX) $(CXXFLAGS) $(OBJECTS) $(LDFLAGS) -o $(NAME).so
+	$(CXX) $(CXXFLAGS) $(GUI_OBJECTS) $(GUI_LDFLAGS) -o $(NAME)_ui.so
+
+nogui :
+	$(CXX) $(CXXFLAGS) $(OBJECTS) $(LDFLAGS) -o $(NAME).so

--- a/LV2/kpp_deadgate/Makefile
+++ b/LV2/kpp_deadgate/Makefile
@@ -1,0 +1,79 @@
+	# check if user is root
+	user = $(shell whoami)
+	ifeq ($(user),root)
+	INSTALL_LV2_DIR = /usr/lib/lv2
+	INSTALL_LADSPA_DIR = /usr/lib/lv2
+	else 
+	INSTALL_LV2_DIR = ~/.lv2
+	INSTALL_LADSPA_DIR = ~/.ladspa
+	endif
+
+	# set bundle name
+	NAME = kpp_deadgate
+	BUNDLE = $(NAME).lv2
+	VER = 1.0
+	# set compile flags
+	CXXFLAGS += -shared -pthread -O2 -fPIC -Wl,--no-as-needed 
+	LDFLAGS +=  -lm -I. '-DDLLEXT=".so"' '-DPLUGIN_URI="https://faustlv2.bitbucket.io/$(NAME)"' -DFAUST_META=1 -DFAUST_MIDICC=1 -DFAUST_MTS=1 -DFAUST_UI=0 -DVOICE_CTRLS=1 
+	GUI_LDFLAGS += -I. -lm `pkg-config --cflags --libs cairo` -L/usr/X11/lib -lX11  -DPLUGIN_URI=\"https://faustlv2.bitbucket.io/$(NAME)\" -DFAUST_META=1 -DFAUST_MIDICC=1 -DFAUST_MTS=1 -DFAUST_UI=1 -DVOICE_CTRLS=1
+	# invoke build files
+	OBJECTS = faust-generated/$(NAME).cpp 
+	GUI_OBJECTS = $(NAME)_ui.src/$(NAME)_gui.c
+	## output style (bash colours)
+	BLUE = "\033[1;34m"
+	RED =  "\033[1;31m"
+	NONE = "\033[0m"
+
+.PHONY : all faust clean gui nogui LV2 LADSPA install uninstall 
+
+all : nogui
+	@mkdir -p ./$(BUNDLE)
+	@mv ./*.so ./$(BUNDLE)
+	@if [ -f ./$(BUNDLE)/$(NAME).so ]; then echo $(BLUE)"build finish, now run make install"; \
+	else echo $(RED)"sorry, build failed"; fi
+	@echo $(NONE)
+
+LADSPA :
+	@faust2ladspa ../../LADSPA/$(NAME)/$(NAME).dsp
+
+LV2 : all
+
+faust:
+	@echo $(BLUE)"regenerate from faust dsp file"$(NONE)
+	@mkdir -p ./faust-temp
+	@cp $(NAME).dsp  faust-temp
+	@faust2lv2 -keep ./faust-temp/$(NAME).dsp
+	@cp ./faust-temp/$(NAME)/$(NAME).cpp ./faust-generated
+	@rm -rf faust-temp
+	@echo ". ." $(BLUE)", done"$(NONE)
+
+clean :
+	@rm -f ./$(BUNDLE)/$(NAME).so
+	@rm -f ./$(BUNDLE)/$(NAME)ui.so
+	@rm -f ../../LADSPA/$(NAME)/$(NAME).su
+	@echo $(BLUE)"clean up"$(NONE)
+
+install :
+	@if [ -f ../../LADSPA/$(NAME)/$(NAME).so ]; then \
+	echo $(BLUE)"install LADSPA version to $(INSTALL_LADSPA_DIR)"; \
+	mkdir -p $(DESTDIR)$(INSTALL_LADSPA_DIR); \
+	cp -r ../../LADSPA/$(NAME)/$(NAME).so $(DESTDIR)$(INSTALL_LADSPA_DIR)/$(NAME).so; fi
+ifneq ("$(wildcard ./$(BUNDLE))","")
+	@mkdir -p $(DESTDIR)$(INSTALL_LV2_DIR)/$(BUNDLE)
+	@echo $(BLUE)"install LV2 version to $(INSTALL_LV2_DIR)"$(NONE)
+	@cp -r ./$(BUNDLE)/* $(DESTDIR)$(INSTALL_LV2_DIR)/$(BUNDLE)
+else
+	@echo ". ." $(BLUE)", you must build first"$(NONE)
+endif
+
+uninstall :
+	@rm -rf $(INSTALL_LV2_DIR)/$(BUNDLE)
+	@rm -rf $(INSTALL_LADSPA_DIR)/$(NAME).so
+	@echo ". ." $(BLUE)", done"$(NONE)
+
+gui : 
+	$(CXX) $(CXXFLAGS) $(OBJECTS) $(LDFLAGS) -o $(NAME).so
+	$(CXX) $(CXXFLAGS) $(GUI_OBJECTS) $(GUI_LDFLAGS) -o $(NAME)_ui.so
+
+nogui :
+	$(CXX) $(CXXFLAGS) $(OBJECTS) $(LDFLAGS) -o $(NAME).so

--- a/LV2/kpp_deadgate/Makefile
+++ b/LV2/kpp_deadgate/Makefile
@@ -2,7 +2,7 @@
 	user = $(shell whoami)
 	ifeq ($(user),root)
 	INSTALL_LV2_DIR = /usr/lib/lv2
-	INSTALL_LADSPA_DIR = /usr/lib/lv2
+	INSTALL_LADSPA_DIR = /usr/lib/ladspa
 	else 
 	INSTALL_LV2_DIR = ~/.lv2
 	INSTALL_LADSPA_DIR = ~/.ladspa

--- a/LV2/kpp_distruction/Makefile
+++ b/LV2/kpp_distruction/Makefile
@@ -2,7 +2,7 @@
 	user = $(shell whoami)
 	ifeq ($(user),root)
 	INSTALL_LV2_DIR = /usr/lib/lv2
-	INSTALL_LADSPA_DIR = /usr/lib/lv2
+	INSTALL_LADSPA_DIR = /usr/lib/ladspa
 	else 
 	INSTALL_LV2_DIR = ~/.lv2
 	INSTALL_LADSPA_DIR = ~/.ladspa

--- a/LV2/kpp_distruction/Makefile
+++ b/LV2/kpp_distruction/Makefile
@@ -1,0 +1,79 @@
+	# check if user is root
+	user = $(shell whoami)
+	ifeq ($(user),root)
+	INSTALL_LV2_DIR = /usr/lib/lv2
+	INSTALL_LADSPA_DIR = /usr/lib/lv2
+	else 
+	INSTALL_LV2_DIR = ~/.lv2
+	INSTALL_LADSPA_DIR = ~/.ladspa
+	endif
+
+	# set bundle name
+	NAME = kpp_distruction
+	BUNDLE = $(NAME).lv2
+	VER = 1.0
+	# set compile flags
+	CXXFLAGS += -shared -pthread -O2 -fPIC -Wl,--no-as-needed 
+	LDFLAGS +=  -lm -I. '-DDLLEXT=".so"' '-DPLUGIN_URI="https://faustlv2.bitbucket.io/$(NAME)"' -DFAUST_META=1 -DFAUST_MIDICC=1 -DFAUST_MTS=1 -DFAUST_UI=0 -DVOICE_CTRLS=1 
+	GUI_LDFLAGS += -I. -lm `pkg-config --cflags --libs cairo` -L/usr/X11/lib -lX11  -DPLUGIN_URI=\"https://faustlv2.bitbucket.io/$(NAME)\" -DFAUST_META=1 -DFAUST_MIDICC=1 -DFAUST_MTS=1 -DFAUST_UI=1 -DVOICE_CTRLS=1
+	# invoke build files
+	OBJECTS = faust-generated/$(NAME).cpp 
+	GUI_OBJECTS = $(NAME)_ui.scr/$(NAME)_gui.c
+	## output style (bash colours)
+	BLUE = "\033[1;34m"
+	RED =  "\033[1;31m"
+	NONE = "\033[0m"
+
+.PHONY : all faust clean gui nogui LV2 LADSPA install uninstall 
+
+all : nogui
+	@mkdir -p ./$(BUNDLE)
+	@mv ./*.so ./$(BUNDLE)
+	@if [ -f ./$(BUNDLE)/$(NAME).so ]; then echo $(BLUE)"build finish, now run make install"; \
+	else echo $(RED)"sorry, build failed"; fi
+	@echo $(NONE)
+
+LADSPA :
+	@faust2ladspa ../../LADSPA/$(NAME)/$(NAME).dsp
+
+LV2 : all
+
+faust:
+	@echo $(BLUE)"regenerate from faust dsp file"$(NONE)
+	@mkdir -p ./faust-temp
+	@cp $(NAME).dsp  faust-temp
+	@faust2lv2 -keep ./faust-temp/$(NAME).dsp
+	@cp ./faust-temp/$(NAME)/$(NAME).cpp ./faust-generated
+	@rm -rf faust-temp
+	@echo ". ." $(BLUE)", done"$(NONE)
+
+clean :
+	@rm -f ./$(BUNDLE)/$(NAME).so
+	@rm -f ./$(BUNDLE)/$(NAME)ui.so
+	@rm -f ../../LADSPA/$(NAME)/$(NAME).su
+	@echo $(BLUE)"clean up"$(NONE)
+
+install :
+	@if [ -f ../../LADSPA/$(NAME)/$(NAME).so ]; then \
+	echo $(BLUE)"install LADSPA version to $(INSTALL_LADSPA_DIR)"; \
+	mkdir -p $(DESTDIR)$(INSTALL_LADSPA_DIR); \
+	cp -r ../../LADSPA/$(NAME)/$(NAME).so $(DESTDIR)$(INSTALL_LADSPA_DIR)/$(NAME).so; fi
+ifneq ("$(wildcard ./$(BUNDLE))","")
+	@mkdir -p $(DESTDIR)$(INSTALL_LV2_DIR)/$(BUNDLE)
+	@echo $(BLUE)"install LV2 version to $(INSTALL_LV2_DIR)"$(NONE)
+	@cp -r ./$(BUNDLE)/* $(DESTDIR)$(INSTALL_LV2_DIR)/$(BUNDLE)
+else
+	@echo ". ." $(BLUE)", you must build first"$(NONE)
+endif
+
+uninstall :
+	@rm -rf $(INSTALL_LV2_DIR)/$(BUNDLE)
+	@rm -rf $(INSTALL_LADSPA_DIR)/$(NAME).so
+	@echo ". ." $(BLUE)", done"$(NONE)
+
+gui : 
+	$(CXX) $(CXXFLAGS) $(OBJECTS) $(LDFLAGS) -o $(NAME).so
+	$(CXX) $(CXXFLAGS) $(GUI_OBJECTS) $(GUI_LDFLAGS) -o $(NAME)_ui.so
+
+nogui :
+	$(CXX) $(CXXFLAGS) $(OBJECTS) $(LDFLAGS) -o $(NAME).so

--- a/LV2/kpp_fuzz/Makefile
+++ b/LV2/kpp_fuzz/Makefile
@@ -1,0 +1,79 @@
+	# check if user is root
+	user = $(shell whoami)
+	ifeq ($(user),root)
+	INSTALL_LV2_DIR = /usr/lib/lv2
+	INSTALL_LADSPA_DIR = /usr/lib/lv2
+	else 
+	INSTALL_LV2_DIR = ~/.lv2
+	INSTALL_LADSPA_DIR = ~/.ladspa
+	endif
+
+	# set bundle name
+	NAME = kpp_fuzz
+	BUNDLE = $(NAME).lv2
+	VER = 1.0
+	# set compile flags
+	CXXFLAGS += -shared -pthread -O2 -fPIC -Wl,--no-as-needed 
+	LDFLAGS +=  -lm -I. '-DDLLEXT=".so"' '-DPLUGIN_URI="https://faustlv2.bitbucket.io/$(NAME)"' -DFAUST_META=1 -DFAUST_MIDICC=1 -DFAUST_MTS=1 -DFAUST_UI=0 -DVOICE_CTRLS=1 
+	GUI_LDFLAGS += -I. -lm `pkg-config --cflags --libs cairo` -L/usr/X11/lib -lX11  -DPLUGIN_URI=\"https://faustlv2.bitbucket.io/$(NAME)\" -DFAUST_META=1 -DFAUST_MIDICC=1 -DFAUST_MTS=1 -DFAUST_UI=1 -DVOICE_CTRLS=1
+	# invoke build files
+	OBJECTS = faust-generated/$(NAME).cpp 
+	GUI_OBJECTS = $(NAME)_ui.src/$(NAME)_gui.c
+	## output style (bash colours)
+	BLUE = "\033[1;34m"
+	RED =  "\033[1;31m"
+	NONE = "\033[0m"
+
+.PHONY : all faust clean gui nogui LV2 LADSPA install uninstall 
+
+all : gui
+	@mkdir -p ./$(BUNDLE)
+	@mv ./*.so ./$(BUNDLE)
+	@if [ -f ./$(BUNDLE)/$(NAME).so ]; then echo $(BLUE)"build finish, now run make install"; \
+	else echo $(RED)"sorry, build failed"; fi
+	@echo $(NONE)
+
+LADSPA :
+	@faust2ladspa ../../LADSPA/$(NAME)/$(NAME).dsp
+
+LV2 : all
+
+faust:
+	@echo $(BLUE)"regenerate from faust dsp file"$(NONE)
+	@mkdir -p ./faust-temp
+	@cp $(NAME).dsp  faust-temp
+	@faust2lv2 -keep ./faust-temp/$(NAME).dsp
+	@cp ./faust-temp/$(NAME)/$(NAME).cpp ./faust-generated
+	@rm -rf faust-temp
+	@echo ". ." $(BLUE)", done"$(NONE)
+
+clean :
+	@rm -f ./$(BUNDLE)/$(NAME).so
+	@rm -f ./$(BUNDLE)/$(NAME)ui.so
+	@rm -f ../../LADSPA/$(NAME)/$(NAME).su
+	@echo $(BLUE)"clean up"$(NONE)
+
+install :
+	@if [ -f ../../LADSPA/$(NAME)/$(NAME).so ]; then \
+	echo $(BLUE)"install LADSPA version to $(INSTALL_LADSPA_DIR)"; \
+	mkdir -p $(DESTDIR)$(INSTALL_LADSPA_DIR); \
+	cp -r ../../LADSPA/$(NAME)/$(NAME).so $(DESTDIR)$(INSTALL_LADSPA_DIR)/$(NAME).so; fi
+ifneq ("$(wildcard ./$(BUNDLE))","")
+	@mkdir -p $(DESTDIR)$(INSTALL_LV2_DIR)/$(BUNDLE)
+	@echo $(BLUE)"install LV2 version to $(INSTALL_LV2_DIR)"$(NONE)
+	@cp -r ./$(BUNDLE)/* $(DESTDIR)$(INSTALL_LV2_DIR)/$(BUNDLE)
+else
+	@echo ". ." $(BLUE)", you must build first"$(NONE)
+endif
+
+uninstall :
+	@rm -rf $(INSTALL_LV2_DIR)/$(BUNDLE)
+	@rm -rf $(INSTALL_LADSPA_DIR)/$(NAME).so
+	@echo ". ." $(BLUE)", done"$(NONE)
+
+gui : 
+	$(CXX) $(CXXFLAGS) $(OBJECTS) $(LDFLAGS) -o $(NAME).so
+	$(CXX) $(CXXFLAGS) $(GUI_OBJECTS) $(GUI_LDFLAGS) -o $(NAME)_ui.so
+
+nogui :
+	$(CXX) $(CXXFLAGS) $(OBJECTS) $(LDFLAGS) -o $(NAME).so

--- a/LV2/kpp_fuzz/Makefile
+++ b/LV2/kpp_fuzz/Makefile
@@ -2,7 +2,7 @@
 	user = $(shell whoami)
 	ifeq ($(user),root)
 	INSTALL_LV2_DIR = /usr/lib/lv2
-	INSTALL_LADSPA_DIR = /usr/lib/lv2
+	INSTALL_LADSPA_DIR = /usr/lib/ladspa
 	else 
 	INSTALL_LV2_DIR = ~/.lv2
 	INSTALL_LADSPA_DIR = ~/.ladspa

--- a/LV2/kpp_octaver/Makefile
+++ b/LV2/kpp_octaver/Makefile
@@ -1,0 +1,79 @@
+	# check if user is root
+	user = $(shell whoami)
+	ifeq ($(user),root)
+	INSTALL_LV2_DIR = /usr/lib/lv2
+	INSTALL_LADSPA_DIR = /usr/lib/lv2
+	else 
+	INSTALL_LV2_DIR = ~/.lv2
+	INSTALL_LADSPA_DIR = ~/.ladspa
+	endif
+
+	# set bundle name
+	NAME = kpp_octaver
+	BUNDLE = $(NAME).lv2
+	VER = 1.0
+	# set compile flags
+	CXXFLAGS += -shared -pthread -O2 -fPIC -Wl,--no-as-needed 
+	LDFLAGS +=  -lm -I. '-DDLLEXT=".so"' '-DPLUGIN_URI="https://faustlv2.bitbucket.io/$(NAME)"' -DFAUST_META=1 -DFAUST_MIDICC=1 -DFAUST_MTS=1 -DFAUST_UI=0 -DVOICE_CTRLS=1 
+	GUI_LDFLAGS += -I. -lm `pkg-config --cflags --libs cairo` -L/usr/X11/lib -lX11  -DPLUGIN_URI=\"https://faustlv2.bitbucket.io/$(NAME)\" -DFAUST_META=1 -DFAUST_MIDICC=1 -DFAUST_MTS=1 -DFAUST_UI=1 -DVOICE_CTRLS=1
+	# invoke build files
+	OBJECTS = faust-generated/$(NAME).cpp 
+	GUI_OBJECTS = $(NAME)_ui.src/$(NAME)_gui.c
+	## output style (bash colours)
+	BLUE = "\033[1;34m"
+	RED =  "\033[1;31m"
+	NONE = "\033[0m"
+
+.PHONY : all faust clean gui nogui LV2 LADSPA install uninstall 
+
+all : nogui
+	@mkdir -p ./$(BUNDLE)
+	@mv ./*.so ./$(BUNDLE)
+	@if [ -f ./$(BUNDLE)/$(NAME).so ]; then echo $(BLUE)"build finish, now run make install"; \
+	else echo $(RED)"sorry, build failed"; fi
+	@echo $(NONE)
+
+LADSPA :
+	@faust2ladspa ../../LADSPA/$(NAME)/$(NAME).dsp
+
+LV2 : all
+
+faust:
+	@echo $(BLUE)"regenerate from faust dsp file"$(NONE)
+	@mkdir -p ./faust-temp
+	@cp $(NAME).dsp  faust-temp
+	@faust2lv2 -keep ./faust-temp/$(NAME).dsp
+	@cp ./faust-temp/$(NAME)/$(NAME).cpp ./faust-generated
+	@rm -rf faust-temp
+	@echo ". ." $(BLUE)", done"$(NONE)
+
+clean :
+	@rm -f ./$(BUNDLE)/$(NAME).so
+	@rm -f ./$(BUNDLE)/$(NAME)ui.so
+	@rm -f ../../LADSPA/$(NAME)/$(NAME).su
+	@echo $(BLUE)"clean up"$(NONE)
+
+install :
+	@if [ -f ../../LADSPA/$(NAME)/$(NAME).so ]; then \
+	echo $(BLUE)"install LADSPA version to $(INSTALL_LADSPA_DIR)"; \
+	mkdir -p $(DESTDIR)$(INSTALL_LADSPA_DIR); \
+	cp -r ../../LADSPA/$(NAME)/$(NAME).so $(DESTDIR)$(INSTALL_LADSPA_DIR)/$(NAME).so; fi
+ifneq ("$(wildcard ./$(BUNDLE))","")
+	@mkdir -p $(DESTDIR)$(INSTALL_LV2_DIR)/$(BUNDLE)
+	@echo $(BLUE)"install LV2 version to $(INSTALL_LV2_DIR)"$(NONE)
+	@cp -r ./$(BUNDLE)/* $(DESTDIR)$(INSTALL_LV2_DIR)/$(BUNDLE)
+else
+	@echo ". ." $(BLUE)", you must build first"$(NONE)
+endif
+
+uninstall :
+	@rm -rf $(INSTALL_LV2_DIR)/$(BUNDLE)
+	@rm -rf $(INSTALL_LADSPA_DIR)/$(NAME).so
+	@echo ". ." $(BLUE)", done"$(NONE)
+
+gui : 
+	$(CXX) $(CXXFLAGS) $(OBJECTS) $(LDFLAGS) -o $(NAME).so
+	$(CXX) $(CXXFLAGS) $(GUI_OBJECTS) $(GUI_LDFLAGS) -o $(NAME)_ui.so
+
+nogui :
+	$(CXX) $(CXXFLAGS) $(OBJECTS) $(LDFLAGS) -o $(NAME).so

--- a/LV2/kpp_octaver/Makefile
+++ b/LV2/kpp_octaver/Makefile
@@ -2,7 +2,7 @@
 	user = $(shell whoami)
 	ifeq ($(user),root)
 	INSTALL_LV2_DIR = /usr/lib/lv2
-	INSTALL_LADSPA_DIR = /usr/lib/lv2
+	INSTALL_LADSPA_DIR = /usr/lib/ladspa
 	else 
 	INSTALL_LV2_DIR = ~/.lv2
 	INSTALL_LADSPA_DIR = ~/.ladspa

--- a/LV2/kpp_single2humbucker/Makefile
+++ b/LV2/kpp_single2humbucker/Makefile
@@ -1,0 +1,79 @@
+	# check if user is root
+	user = $(shell whoami)
+	ifeq ($(user),root)
+	INSTALL_LV2_DIR = /usr/lib/lv2
+	INSTALL_LADSPA_DIR = /usr/lib/lv2
+	else 
+	INSTALL_LV2_DIR = ~/.lv2
+	INSTALL_LADSPA_DIR = ~/.ladspa
+	endif
+
+	# set bundle name
+	NAME = kpp_single2humbucker
+	BUNDLE = $(NAME).lv2
+	VER = 1.0
+	# set compile flags
+	CXXFLAGS += -shared -pthread -O2 -fPIC -Wl,--no-as-needed 
+	LDFLAGS +=  -lm -I. '-DDLLEXT=".so"' '-DPLUGIN_URI="https://faustlv2.bitbucket.io/$(NAME)"' -DFAUST_META=1 -DFAUST_MIDICC=1 -DFAUST_MTS=1 -DFAUST_UI=0 -DVOICE_CTRLS=1 
+	GUI_LDFLAGS += -I. -lm `pkg-config --cflags --libs cairo` -L/usr/X11/lib -lX11  -DPLUGIN_URI=\"https://faustlv2.bitbucket.io/$(NAME)\" -DFAUST_META=1 -DFAUST_MIDICC=1 -DFAUST_MTS=1 -DFAUST_UI=1 -DVOICE_CTRLS=1
+	# invoke build files
+	OBJECTS = faust-generated/$(NAME).cpp 
+	GUI_OBJECTS = $(NAME)_ui.src/$(NAME)_gui.c
+	## output style (bash colours)
+	BLUE = "\033[1;34m"
+	RED =  "\033[1;31m"
+	NONE = "\033[0m"
+
+.PHONY : all faust clean gui nogui LV2 LADSPA install uninstall 
+
+all : nogui
+	@mkdir -p ./$(BUNDLE)
+	@mv ./*.so ./$(BUNDLE)
+	@if [ -f ./$(BUNDLE)/$(NAME).so ]; then echo $(BLUE)"build finish, now run make install"; \
+	else echo $(RED)"sorry, build failed"; fi
+	@echo $(NONE)
+
+LADSPA :
+	@faust2ladspa ../../LADSPA/$(NAME)/$(NAME).dsp
+
+LV2 : all
+
+faust:
+	@echo $(BLUE)"regenerate from faust dsp file"$(NONE)
+	@mkdir -p ./faust-temp
+	@cp $(NAME).dsp  faust-temp
+	@faust2lv2 -keep ./faust-temp/$(NAME).dsp
+	@cp ./faust-temp/$(NAME)/$(NAME).cpp ./faust-generated
+	@rm -rf faust-temp
+	@echo ". ." $(BLUE)", done"$(NONE)
+
+clean :
+	@rm -f ./$(BUNDLE)/$(NAME).so
+	@rm -f ./$(BUNDLE)/$(NAME)ui.so
+	@rm -f ../../LADSPA/$(NAME)/$(NAME).su
+	@echo $(BLUE)"clean up"$(NONE)
+
+install :
+	@if [ -f ../../LADSPA/$(NAME)/$(NAME).so ]; then \
+	echo $(BLUE)"install LADSPA version to $(INSTALL_LADSPA_DIR)"; \
+	mkdir -p $(DESTDIR)$(INSTALL_LADSPA_DIR); \
+	cp -r ../../LADSPA/$(NAME)/$(NAME).so $(DESTDIR)$(INSTALL_LADSPA_DIR)/$(NAME).so; fi
+ifneq ("$(wildcard ./$(BUNDLE))","")
+	@mkdir -p $(DESTDIR)$(INSTALL_LV2_DIR)/$(BUNDLE)
+	@echo $(BLUE)"install LV2 version to $(INSTALL_LV2_DIR)"$(NONE)
+	@cp -r ./$(BUNDLE)/* $(DESTDIR)$(INSTALL_LV2_DIR)/$(BUNDLE)
+else
+	@echo ". ." $(BLUE)", you must build first"$(NONE)
+endif
+
+uninstall :
+	@rm -rf $(INSTALL_LV2_DIR)/$(BUNDLE)
+	@rm -rf $(INSTALL_LADSPA_DIR)/$(NAME).so
+	@echo ". ." $(BLUE)", done"$(NONE)
+
+gui : 
+	$(CXX) $(CXXFLAGS) $(OBJECTS) $(LDFLAGS) -o $(NAME).so
+	$(CXX) $(CXXFLAGS) $(GUI_OBJECTS) $(GUI_LDFLAGS) -o $(NAME)_ui.so
+
+nogui :
+	$(CXX) $(CXXFLAGS) $(OBJECTS) $(LDFLAGS) -o $(NAME).so

--- a/LV2/kpp_single2humbucker/Makefile
+++ b/LV2/kpp_single2humbucker/Makefile
@@ -2,7 +2,7 @@
 	user = $(shell whoami)
 	ifeq ($(user),root)
 	INSTALL_LV2_DIR = /usr/lib/lv2
-	INSTALL_LADSPA_DIR = /usr/lib/lv2
+	INSTALL_LADSPA_DIR = /usr/lib/ladspa
 	else 
 	INSTALL_LV2_DIR = ~/.lv2
 	INSTALL_LADSPA_DIR = ~/.ladspa

--- a/LV2/kpp_tubeamp/Makefile
+++ b/LV2/kpp_tubeamp/Makefile
@@ -1,0 +1,67 @@
+	# check if user is root
+	user = $(shell whoami)
+	ifeq ($(user),root)
+	INSTALL_LV2_DIR = /usr/lib/lv2
+	else 
+	INSTALL_LV2_DIR = ~/.lv2
+	endif
+
+	# set bundle name
+	NAME = kpp_tubeamp
+	BUNDLE = $(NAME).lv2
+	VER = 1.0
+	# set compile flags
+	CXXFLAGS += -shared -pthread -O2 -Wall -fPIC -Wl,--no-as-needed 
+	LDFLAGS += -lfftw3 -lfftw3f -lm -I. '-DDLLEXT=".so"' '-DPLUGIN_URI="https://faustlv2.bitbucket.io/$(NAME)"' -DFAUST_META=1 -DFAUST_MIDICC=1 -DFAUST_MTS=1 -DFAUST_UI=0 -DVOICE_CTRLS=1 
+	GUI_LDFLAGS += -I. -lm `pkg-config --cflags --libs cairo` -L/usr/X11/lib -lX11  -DPLUGIN_URI=\"https://faustlv2.bitbucket.io/$(NAME)\" -DFAUST_META=1 -DFAUST_MIDICC=1 -DFAUST_MTS=1 -DFAUST_UI=1 -DVOICE_CTRLS=1
+	# invoke build files
+	OBJECTS = $(NAME).cpp 
+	GUI_OBJECTS = $(NAME)_ui.src/$(NAME)_gui.c
+	## output style (bash colours)
+	BLUE = "\033[1;34m"
+	RED =  "\033[1;31m"
+	NONE = "\033[0m"
+
+.PHONY : all faust clean nogui LV2 LADSPA install uninstall 
+
+all :  $(NAME)
+	@mkdir -p ./$(BUNDLE)
+	@mv ./*.so ./$(BUNDLE)
+	@if [ -f ./$(BUNDLE)/$(NAME).so ]; then echo $(BLUE)"build finish, now run make install"; \
+	else echo $(RED)"sorry, build failed"; fi
+	@echo $(NONE)
+
+LADSPA :
+	@echo $(BLUE)"LADSPA pass"$(NONE)
+
+LV2 : all
+
+faust:
+	@echo $(BLUE)"regenerate from faust dsp file"$(NONE)
+	@faust kpp_tubeamp.dsp >faust-generated/$(NAME)_dsp.cpp
+	@echo ". ." $(BLUE)", done"$(NONE)
+
+clean :
+	@rm -f ./$(BUNDLE)/$(NAME).so
+	@rm -f ./$(BUNDLE)/$(NAME)ui.so
+	@echo $(BLUE)"clean up"$(NONE)
+
+install :
+ifneq ("$(wildcard ./$(BUNDLE))","")
+	@mkdir -p $(DESTDIR)$(INSTALL_LV2_DIR)/$(BUNDLE)
+	cp -r ./$(BUNDLE)/* $(DESTDIR)$(INSTALL_LV2_DIR)/$(BUNDLE)
+	@echo ". ." $(BLUE)", done"$(NONE)
+else
+	@echo ". ." $(BLUE)", you must build first"$(NONE)
+endif
+
+uninstall :
+	@rm -rf $(INSTALL_LV2_DIR)/$(BUNDLE)
+	@echo ". ." $(BLUE)", done"$(NONE)
+
+$(NAME) :
+	$(CXX) $(CXXFLAGS) $(OBJECTS) $(LDFLAGS) -o $(NAME).so
+	$(CXX) $(CXXFLAGS)  $(GUI_OBJECTS) $(GUI_LDFLAGS) -o $(NAME)ui.so
+
+nogui :
+	$(CXX) $(CXXFLAGS) $(OBJECTS) $(LDFLAGS) -o $(NAME).so

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,10 @@
+
+SUBDIR := $(wildcard LV2/kpp*/)
+#SUBDIR := $(filter-out  debian/, $(SUBDIR))
+
+.PHONY: $(SUBDIR) recurse
+
+$(MAKECMDGOALS) recurse: $(SUBDIR)
+
+$(SUBDIR):
+	@exec $(MAKE) -C $@ $(MAKECMDGOALS)


### PR DESCRIPTION
Hi 

Introduce a build system based on makefiles. It allow building and install all plugins from top-level directory. 
Default build , aka 'make' build the LV2 plugins, 'make LADSPA' build the ladspa plugins, 'make LV2 LADSPA' build both versions. 
'make faust' regenerate the faust generated *-cpp files. 
As said, make could be involved from top-level, but you could as well go to every single plugin directory and involve make for a single plug, eg. if you would regenerate just a single plug, instead all.  
The rest is the usual stuff, 'clean', 'install', 'uninstall'.  

To 'install', it will install ladspa version, if it was builded, to ~/.ladspa when involved as user, when involved as root, it will install to /usr/lib/ladspa.
The same goes for LV2, when involved as user, installation goes to ~/.lv2, as root to /usr/lib/lv2. 

Install path could be prefixed with the usual DEST_DIR variable and overwritten with INSTALL_LV2_DIR and INSTALL_LADSPA_DIR (make install DIR=...)

regards
hermann